### PR TITLE
Adding a find all function that will return all the matched data (and st...art position) it finds according to the pattern.

### DIFF
--- a/korg/korg.py
+++ b/korg/korg.py
@@ -12,6 +12,8 @@ class LineGrokker(object):
         if m:
             return m.groupdict()
 
+    def find_all(self, data):
+        return map(lambda x: {"position": x.start(), "value": x.group()}, self.regex.finditer(data))
 
 if __name__ == "__main__":
     GLOBALPM = {


### PR DESCRIPTION
For example:
    pr = PatternRepo(['./patterns/'])
    lg = korg.LineGrokker('%{IP:ip_add}', pr)
    print lg.find_all("Lorem 1.1.1.1 ipsum 2.2.2.2 dolor sit 3.3.3.3 amet")
will return [{'position': 6, 'value': '1.1.1.1'}, {'position': 20, 'value': '2.2.2.2'}, {'position': 38, 'value': '3.3.3.3'}]
