### PR TITLE
Bug fix, return multiple values when trying to extract multiple patterns into the same key.

### DIFF
--- a/korg/korg.py
+++ b/korg/korg.py
@@ -10,7 +10,7 @@ class LineGrokker(object):
     def grok(self, data):
         m = self.regex.search(data)
         if m:
-            return m.groupdict()
+            return m.capturesdict()
 
     def find_all(self, data):
         return map(lambda x: {"position": x.start(), "value": x.group()}, self.regex.finditer(data))

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     long_description=open('README.md').read(),
     url='https://github.com/aogaeru/korg',
     name='korg',
-    version='0.0.5',
+    version='0.0.6',
     packages=['korg'],
     data_files=[('patterns', find_pattern_files()), 'README.md'],
     install_requires=['regex >= 2013-06-05'],


### PR DESCRIPTION
example:
pattern: '._%{IP:ip_address}._%{IP:ip_address}.*'
data: 'Mar 16 00:01:25 evita postfix/smtpd[1713]: 168.100.1.4 connect from camomile.cloud9.net[168.100.1.3]'
returns: {'ip_address': ['168.100.1.4', '168.100.1.3']}
